### PR TITLE
Install the robdc package from CRAN mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,16 @@ language: r
 dist: trusty
 sudo: false
 cache: packages
+
+addons:
+  apt:
+    packages:
+      r-cran-rodbc
+
 r:
   - oldrel # when oldrel = 3.1, there are S3 method problems I can't debug
   - release
   - devel
-
-os:
-  - linux
-  - osx
 
 # compiler:
 #   - gcc


### PR DESCRIPTION
RODBC is included in supported package for the ubuntu CRAN mirrors (https://cran.r-project.org/bin/linux/ubuntu/README.html#supported-packages) and is on the [apt-package whitelist](https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise#L10906-L10907) so you can install it using the apt addon without needing `sudo: true`.

I turned off building under OS X as mac binaries are not available for RODBC, so it doesn't seem appropriate to test it there.

Have you considered reducing the size of your build matrix, Travis build machines are a shared resource donated to the community and these builds are quite lengthy.