### PR TITLE
Fix filter_{in}valid x parameter docs

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -17,9 +17,8 @@
 
 #' Filter ICD codes by validity.
 #'
-#' Filters a data.frame of patients for valid or invalid ICD-9
-#'   codes
-#' @param x input vector of ICD codes
+#' Filters a data.frame of patients for valid or invalid ICD codes
+#' @param x a data.frame containing a column of ICD codes
 #' @template icd_name
 #' @template short_code
 #' @template invert


### PR DESCRIPTION
The documentation states `x` is a vector, but https://github.com/jackwasey/icd/blob/1a04cdd041ab39dae8cf0857dcb05e5b5f50efae/R/filter.R#L32 indicates it must be a data frame. We get the following error if you do try it on a vector:
```{r}
> filter_invalid(uranium_pathology$icd10)
Error in filter_invalid(uranium_pathology$icd10) : 
  Assertion on 'x' failed: Must be of type 'data.frame', not 'icd10/factor'.
```