### PR TITLE
Fix download_all_icd_data problems

### DIFF
--- a/R/cim-10-fr.R
+++ b/R/cim-10-fr.R
@@ -8,7 +8,7 @@
       "https://www.atih.sante.fr",
       "plateformes-de-transmission-et-logiciels",
       "logiciels-espace-de-telechargement",
-      "telecharger/gratuit/11616/456"
+      "telecharger/gratuit/12713/456"
     ),
     file_name = "LIBCIM10MULTI.TXT",
     dl_msg = "Working on ICD-10-FR (CIM-10-FR)",

--- a/R/icd10be.R
+++ b/R/icd10be.R
@@ -6,7 +6,7 @@
                             ...) {
   site_file_2017 <-
     "fy2017_reflist_icd-10-be.xlsx_last_updatet_28-07-2017_1.xlsx"
-  fnp <- .download_to_data_raw(
+  fnp <- .download_to_data_cache(
     paste(.icd10be_site,
       .icd10be_url_path,
       site_file_2017,
@@ -28,7 +28,7 @@
   }
   site_file <- "fy2014_reflist_icd-10-be.xlsx"
   .msg("Downloading or getting cached icd10be2014 data")
-  .download_to_data_raw(
+  .download_to_data_cache(
     paste(.icd10be_site,
       .icd10be_url_path,
       site_file,
@@ -58,7 +58,7 @@
 #' \url{https://www.health.belgium.be/sites/default/files/uploads/fields/fpshealth_theme_file/fy2017_reflist_icd-10-be.xlsx_last_updatet_28-07-2017_1.xlsx}
 # nolint end
 #' \url{https://www.health.belgium.be/fr/fy2014reflisticd-10-bexlsx}
-#' @param ... passed to \code{.download_to_data_raw}, e.g., \code{offline =
+#' @param ... passed to \code{.download_to_data_cache}, e.g., \code{offline =
 #'   FALSE}.
 #' @seealso \code{link{parse_icd10be2014_be}}
 #' @keywords internal
@@ -133,7 +133,7 @@
 #'   \url{https://www.health.belgium.be/fr/sante/organisation-des-soins-de-sante/hopitaux/systemes-denregistrement/icd-10-be}
 # nolint end
 #'    \url{https://www.health.belgium.be/fr/fy2014reflisticd-10-bexlsx}
-#' @param ... passed to \code{.download_to_data_raw}, e.g., \code{offline =
+#' @param ... passed to \code{.download_to_data_cache}, e.g., \code{offline =
 #'   FALSE}.
 #' @seealso \code{link{parse_icd10be2014_be}}
 #' @keywords internal

--- a/R/util.R
+++ b/R/util.R
@@ -398,7 +398,8 @@ capitalize_first <- function(x) {
 #' @noRd
 #' @keywords internal
 get_raw_data_dir <- function() {
-  system.file("data-raw", package = "icd")
+  # use mustWork = TRUE to throw an error if the directory is not found
+  system.file("data-raw", package = "icd", mustWork = TRUE)
 }
 
 .stopifnot_year <- function(year) {

--- a/R/who.R
+++ b/R/who.R
@@ -19,7 +19,7 @@
   # memoise package has given me problems and crashes. DIY
   mem_file_name <- paste(
     "WHO", year, lang,
-    gsub("JsonGetChildrenConcepts\\?ConceptId=|&useHtml=false", "", resource),
+    gsub("JsonGetChildrenConcepts\\?ConceptId=|(&|\\?)useHtml=false", "", resource),
     "json",
     sep = "."
   )


### PR DESCRIPTION
This pull includes almost everything I needed to fix to get `download_all_icd_data()` to work properly on a Windows 10 system.

The last fix is that in order for `data-raw` to work as expected (where `.download_to_data_raw` will dump into the package directory), the `data-raw` directory needs to be moved to be under `inst`.  [See the chapter in R Packages.](http://r-pkgs.had.co.nz/data.html#data-extdata).

Fixes:
- issue #185 (files with ? cannot be saved on Windows systems)
- issue #189 (URL changed)
- problem with retrieving `icd10be2014`
