### PR TITLE
Fix compilation errors with clang 17 and modern C++ compilers

### DIFF
--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -74,7 +74,12 @@ LogicalVector icd9CompareVector(const StringVector& x,
 // [[Rcpp::export(icd9_sort_rcpp)]]
 CharacterVector icd9Sort(const CharacterVector &x) {
   CharacterVector y = clone(x);
-  std::sort(y.begin(), y.end(), icd9Compare);
+  // Convert to std::vector to avoid proxy iterator issues with modern C++ compilers
+  std::vector<String> temp(y.begin(), y.end());
+  std::sort(temp.begin(), temp.end(), icd9Compare);
+  for (R_xlen_t i = 0; i < y.size(); ++i) {
+    y[i] = temp[i];
+  }
   return y;
 }
 
@@ -250,7 +255,12 @@ LogicalVector icd10cmCompareVector(const StringVector& x,
 // [[Rcpp::export(icd10cm_sort_rcpp)]]
 CharacterVector icd10cmSort(const CharacterVector &x) {
   auto y = clone(x);
-  std::sort(y.begin(), y.end(), icd10cmCompare);
+  // Convert to std::vector to avoid proxy iterator issues with modern C++ compilers
+  std::vector<String> temp(y.begin(), y.end());
+  std::sort(temp.begin(), temp.end(), icd10cmCompare);
+  for (R_xlen_t i = 0; i < y.size(); ++i) {
+    y[i] = temp[i];
+  }
   return y;
 }
 


### PR DESCRIPTION
The std::sort() function cannot directly operate on Rcpp proxy iterators in modern C++ standard library implementations (particularly clang 17+). This causes compilation failures with errors like:

  error: indirection requires pointer operand
  ('const Rcpp::internal::Proxy_Iterator<...>' invalid)

This commit fixes the issue by:

1. Converting CharacterVector to std::vector<String> before sorting
2. Performing std::sort() on the standard vector (which works correctly)
3. Copying the sorted results back to the CharacterVector

This approach maintains the same functionality while being compatible with both older and newer C++ compiler toolchains.

Fixes compilation on macOS with Apple clang 17.0.0 and similar modern compiler configurations.